### PR TITLE
Speed up for decoding

### DIFF
--- a/crf_tagger.py
+++ b/crf_tagger.py
@@ -23,15 +23,33 @@ class CRFTagger:
 
         self._bos = ["_B-1", "_B-2", "_B-3", "_B-4", "_B-5", "_B-6", "_B-7", "_B-8"]
         self._eos = ["_B+1", "_B+2", "_B+3", "_B+4", "_B+5", "_B+6", "_B+7", "_B+8"]
-
-    def _get_uni_cost(self, x, xpos, tag_id):
-        features = list(map(lambda tmpl: self.get_feature_str(tmpl, x, xpos), self._uni_templates))
-        cost = sum(map(lambda f: self._model.get_uni_feature_cost(f, tag_id), features))
+    
+        self._uni_featurs_tmpl_list, self._uni_features_pos_set = self._get_featurs_tmp_list(self._uni_templates)
+        self._bi_featurs_tmpl_list, self._bi_features_pos_set = self._get_featurs_tmp_list(self._bi_templates)
+        
+    def _get_featurs_tmp_list(self, templates):
+        _features_pos_set = set()
+        _features = []
+        for tmpl in templates:
+            feature_info = {}
+            
+            idx = tmpl.find(':')
+            if idx > 0: feature_info['id'] = tmpl[0:idx + 1]
+            else: feature_info['id'] = tmpl
+            
+            feature_info['pos'] = self._re_x.findall(tmpl)
+            
+            for p in feature_info['pos']: _features_pos_set.add(p)
+            
+            _features.append(feature_info)
+        return _features, _features_pos_set
+        
+    def _get_uni_cost(self, x, xpos, tag_id, features):
+        cost = sum([self._model.get_uni_feature_cost(f, tag_id) for f in features])
         return cost
 
-    def _get_bi_cost(self, x, xpos, left_tag_id, right_tag_id):
-        features = list(map(lambda tmpl: self.get_feature_str(tmpl, x, xpos), self._bi_templates))
-        cost = sum(map(lambda f: self._model.get_bi_feature_cost(f, left_tag_id, right_tag_id), features))
+    def _get_bi_cost(self, x, xpos, left_tag_id, right_tag_id, features):
+        cost = sum([self._model.get_bi_feature_cost(f, left_tag_id, right_tag_id) for f in features])
         return cost 
     
     def _check_and_extend_buckets(self, need_size):
@@ -41,15 +59,17 @@ class CRFTagger:
                 self._buckets.append(bucket)
 
     def _get_bucket_cost(self, x, xpos):
+        features = self.get_feature_str_list(x, xpos, self._uni_featurs_tmpl_list, self._uni_features_pos_set)
         for tag_id, node in enumerate(self._buckets[xpos]):
-            node.cost += self._get_uni_cost(x, xpos, tag_id)
+            node.cost += self._get_uni_cost(x, xpos, tag_id, features)
 
     def _get_arc_cost(self, x, xpos):
+        features = self.get_feature_str_list(x, xpos, self._bi_featurs_tmpl_list, self._bi_features_pos_set)
         possible_arc = []
         for right_tag_id, node_right in enumerate(self._buckets[xpos]):
-            possible_arc.clear()
+            possible_arc = []
             for left_tag_id, node_left in enumerate(self._buckets[xpos - 1]):
-                cost = node_left.cost + self._get_bi_cost(x, xpos, left_tag_id, right_tag_id)
+                cost = node_left.cost + self._get_bi_cost(x, xpos, left_tag_id, right_tag_id, features)
                 possible_arc.append((cost, left_tag_id))
             left = max(possible_arc)
             node_right.previous_node = left[1]
@@ -78,7 +98,7 @@ class CRFTagger:
             result[bucket_id] = tag_id
             tag_id = self._buckets[bucket_id][tag_id].previous_node
             bucket_id -= 1
-
+        
         return result
 
     def tag(self, x):
@@ -87,15 +107,20 @@ class CRFTagger:
         result_tag = self._find_best_result(len(x) - 1)
         return list(map(lambda y: self._model.get_tag_str(y), result_tag))
 
-    def get_feature_str(self, template_str, x, xpos):
-        def _repl(matchobj):
-            row = int(matchobj.group(1)) + xpos
-            if row < 0:
-                return self._bos[-row - 1]
-            elif row >= len(x): 
-                return self._eos[row - len(x)]
-            column = int(matchobj.group(2))
-            return x[row][column]
-
-        return self._re_x.sub(_repl, template_str)
+    def get_feature_str_list(self, x, xpos, _featurs_tmpl_list, _features_pos_set):
+        features = []
+        pos_list = {}
+        
+        for p in list(_features_pos_set):
+            row = int(p[0]) + xpos
+            col = int(p[1])
+            if row < 0: pos_list[p] = self._bos[-row - 1]
+            elif row >= len(x): pos_list[p] = self._eos[row - len(x)]
+            else: pos_list[p] = x[row][col]
+        
+        for tmpl_info in _featurs_tmpl_list:
+            feature_str = tmpl_info['id'] + '/'.join([pos_list[p] for p in tmpl_info['pos']])
+            features.append(feature_str)
+            
+        return features
 


### PR DESCRIPTION
Reduce the frequency of string comparisons, speed up for decoding

Time testing 
model: ctb_seg.pickle
testing: msr_test.utf8
(All in your repo)

Testing code
```
start = time.time()
with codecs.open('msr_test.utf8', encoding='utf-8') as fp:
    for line in fp:
        line = line.strip()
        x = list(map(lambda x: [x], line))
        _tag_to_seg(line, tagger.tag(x))
end = time.time()
print(end-start)
```

Orginal crf_tagger
58.29537534713745 (sec)

Modify crf_tagger
20.336644411087036 (sec)

